### PR TITLE
Add Corporate Emissions Accounting section with Scope 3 Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 - [Carbon Clock](https://lnkd.in/g6EGw6mr) - How much of our carbon budget is remaining?
 - [Climate Change Tracker](https://climatechangetracker.org/livestream) - Live streaming dashboards aggregating GHG emissions
 
+## Corporate Emissions Accounting
+- [Scope 3 Challenge](https://github.com/co3org/Scope3-Challenge) - A structured knowledge base on how companies measure (and fail to measure) their value-chain emissions. Covers all 15 GHG Protocol Scope 3 categories, why spend-based methods can be off by 2–10x, industry case studies across automotive, apparel, finance and food sectors, and the regulatory deadlines companies face under CSRD, SEC, and ISSB S2. Includes real benchmarks from 1,391 company disclosures.
+
 ## Net Zero
 - [Climate Action Tracker](https://climateactiontracker.org/) -  Country Net-zero commitments rated against the Paris goals.
 - [Zero Tracker](https://zerotracker.net/) - Country, region and city targets and plans analysed and rated.


### PR DESCRIPTION
## What this adds

A new **Corporate Emissions Accounting** subsection under Emissions, containing [Scope 3 Challenge](https://github.com/co3org/Scope3-Challenge).

## Why it fits

The current Emissions section covers national/sector tracking tools (Our World in Data, Climate Trace, Carbon Clock) but has no resource explaining **how corporate emissions are measured, reported, and why they are so often wrong**. Corporate Scope 3 — the value-chain emissions companies are required to disclose — is where 70–90% of most companies' real climate impact sits, and where the largest disclosure gaps remain.

## What the resource covers

- All 15 GHG Protocol Scope 3 categories with worked examples
- Why spend-based estimation methods can be off by 2–10x from real emissions
- Industry case studies: automotive OEMs, apparel brands, commercial banks, food & agriculture
- Regulatory deadlines: CSRD (in force), ISSB S2 (adopted by 20+ jurisdictions), SEC Climate Rule
- Empirical benchmarks: disclosure rates, Scope 3 intensity, and category-level analysis across 1,391 companies

## Placement rationale

A new subsection rather than adding to the existing Emissions list keeps the national/macro tracking tools cleanly separated from the corporate accounting methodology resources — which serve a different audience (sustainability teams, ESG analysts, procurement leaders).